### PR TITLE
Fixes 100% CPU load by disabling interactive mode

### DIFF
--- a/aircast/rootfs/etc/services.d/aircast/run
+++ b/aircast/rootfs/etc/services.d/aircast/run
@@ -10,6 +10,9 @@ declare -a options
 
 hass.log.info 'Starting the AirCast server'
 
+# Non-interactive
+options+=(-Z)
+
 # Bind to a specific interface
 if hass.config.has_value 'address'; then
     options+=(-b "$(hass.config.get 'address')")


### PR DESCRIPTION
# Proposed Changes

Disables interactive mode, which causes a 100% load on a single CPU core.
There is no need for the interactive mode in this add-on.

## Related Issues

#2