### PR TITLE
Mark address option optional

### DIFF
--- a/aircast/config.json
+++ b/aircast/config.json
@@ -11,14 +11,13 @@
   "host_network": true,
   "map": ["config:rw"],
   "options": {
-    "address": "",
     "latency_rtp": 0,
     "latency_http": 0,
     "drift": false
   },
   "schema": {
     "log_level": "list(trace|debug|info|notice|warning|error|fatal)?",
-    "address": "str",
+    "address": "str?",
     "latency_rtp": "int",
     "latency_http": "int",
     "drift": "bool"


### PR DESCRIPTION
# Proposed Changes

Marks the address configuration option as optional, so it doesn't trigger "require" a value in the Home Assistant frontend.
