### PR TITLE
Migrate Aircast config out of Home Assistant config folder

### DIFF
--- a/aircast/DOCS.md
+++ b/aircast/DOCS.md
@@ -151,8 +151,8 @@ lack of audio. Note that `latency_rtp` does not delay playback start.
 
 ## Tweaking Aircast
 
-Aircast creates a configuration file called `aircast.xml` in your Home
-Assistant configuration directory. This file allows you to tweak each device
+Aircast creates a configuration file called `aircast.xml` in the add-on
+configuration directory. This file allows you to tweak each device
 separately. Every time it finds a new device, it will be added to that file.
 
 > **NOTE**: It is HIGHLY recommended to stop the addon before making changes

--- a/aircast/config.yaml
+++ b/aircast/config.yaml
@@ -14,7 +14,8 @@ arch:
 hassio_api: true
 host_network: true
 map:
-  - config:rw
+  - addon_config:rw
+  - homeassistant_config:rw
 options:
   latency_rtp: 0
   latency_http: 0

--- a/aircast/rootfs/etc/s6-overlay/s6-rc.d/init-aircast/run
+++ b/aircast/rootfs/etc/s6-overlay/s6-rc.d/init-aircast/run
@@ -6,6 +6,14 @@
 # ==============================================================================
 declare latency
 
+# Migrate add-on data from the Home Assistant config folder,
+# to the add-on configuration folder.
+if ! bashio::fs.directory_exists '/config/aircast.xml' \
+    && bashio::fs.file_exists '/homeassistant/aircast.xml'; then
+    mv /homeassistant/aircast.xml /config/aircast.xml \
+        || bashio::exit.nok "Failed to migrate Aircast configuration"
+fi
+
 # Create a configuration file, if it does not exist yet
 if ! bashio::fs.file_exists '/config/aircast.xml'; then
     cp /etc/aircast.xml /config/aircast.xml


### PR DESCRIPTION
# Proposed Changes

This moves the Aircast configuration out of the Home Assistant configuration folder into its own add-on configuration folder. This ensures the configuration is included in the add-on backups as well.
