### PR TITLE
:fireworks: Updates maintenance/license year to 2025

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 # MIT License
 
-Copyright (c) 2017-2024 Franck Nijhof
+Copyright (c) 2017-2025 Franck Nijhof
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ our [GitHub Repository][repository].
 
 MIT License
 
-Copyright (c) 2017-2024 Franck Nijhof
+Copyright (c) 2017-2025 Franck Nijhof
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -122,7 +122,7 @@ SOFTWARE.
 [i386-shield]: https://img.shields.io/badge/i386-no-red.svg
 [issue]: https://github.com/hassio-addons/addon-aircast/issues
 [license-shield]: https://img.shields.io/github/license/hassio-addons/addon-aircast.svg
-[maintenance-shield]: https://img.shields.io/maintenance/yes/2024.svg
+[maintenance-shield]: https://img.shields.io/maintenance/yes/2025.svg
 [patreon-shield]: https://frenck.dev/wp-content/uploads/2019/12/patreon.png
 [patreon]: https://www.patreon.com/frenck
 [project-stage-shield]: https://img.shields.io/badge/project%20stage-production%20ready-brightgreen.svg

--- a/aircast/.README.j2
+++ b/aircast/.README.j2
@@ -68,7 +68,7 @@ If you are more interested in stable releases of our add-ons:
 [forum]: https://community.home-assistant.io/t/home-assistant-community-add-on-aircast/36742?u=frenck
 [github-sponsors-shield]: https://frenck.dev/wp-content/uploads/2019/12/github_sponsor.png
 [github-sponsors]: https://github.com/sponsors/frenck
-[maintenance-shield]: https://img.shields.io/maintenance/yes/2024.svg
+[maintenance-shield]: https://img.shields.io/maintenance/yes/2025.svg
 [patreon-shield]: https://frenck.dev/wp-content/uploads/2019/12/patreon.png
 [patreon]: https://www.patreon.com/frenck
 [project-stage-shield]: https://img.shields.io/badge/project%20stage-production%20ready-brightgreen.svg

--- a/aircast/DOCS.md
+++ b/aircast/DOCS.md
@@ -204,7 +204,7 @@ check [the contributor's page][contributors].
 
 MIT License
 
-Copyright (c) 2017-2024 Franck Nijhof
+Copyright (c) 2017-2025 Franck Nijhof
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
# Proposed Changes

Happy New Year 🥂 

../Frenck


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated copyright year from 2024 to 2025 in LICENSE.md, README.md, aircast/.README.j2, and DOCS.md
	- Updated maintenance shield URL to reflect the year 2025 in README.md and aircast/.README.j2

<!-- end of auto-generated comment: release notes by coderabbit.ai -->